### PR TITLE
build: bump eazyctrl version

### DIFF
--- a/custom_components/easycontrols/manifest.json
+++ b/custom_components/easycontrols/manifest.json
@@ -8,5 +8,5 @@
   "config_flow": true,
   "version": "0.5.0",
   "codeowners": ["@laszlojakab"],
-  "requirements": ["eazyctrl==0.3"]
+  "requirements": ["eazyctrl==0.4"]
 }


### PR DESCRIPTION
### Description

This PR bumps the eazyctrl package version requirements to 0.4