### PR TITLE
fix: use EntityCategory instance instead of string constant (HA 2022.04)

### DIFF
--- a/custom_components/easycontrols/binary_sensor.py
+++ b/custom_components/easycontrols/binary_sensor.py
@@ -7,8 +7,8 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OPENING, DEVICE_CLASS_PROBLEM, BinarySensorEntity,
     BinarySensorEntityDescription)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_MAC, ENTITY_CATEGORY_DIAGNOSTIC
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.const import CONF_MAC
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -98,7 +98,7 @@ async def async_setup_entry(
                 name=f'{controller.device_name} bypass',
                 icon='mdi:delta',
                 device_class=DEVICE_CLASS_OPENING,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             ),
         ),
         EasyControlBinarySensor(
@@ -109,7 +109,7 @@ async def async_setup_entry(
                 name=f'{controller.device_name} filter change',
                 icon='mdi:air-filter',
                 device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         )
     ])

--- a/custom_components/easycontrols/sensor.py
+++ b/custom_components/easycontrols/sensor.py
@@ -8,9 +8,8 @@ from homeassistant.components.sensor import (STATE_CLASS_MEASUREMENT,
                                              SensorEntityDescription)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (CONF_MAC, DEVICE_CLASS_HUMIDITY,
-                                 DEVICE_CLASS_TEMPERATURE,
-                                 ENTITY_CATEGORY_DIAGNOSTIC)
-from homeassistant.helpers.entity import DeviceInfo
+                                 DEVICE_CLASS_TEMPERATURE)
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import HomeAssistantType
 
@@ -58,7 +57,7 @@ class EasyControlsAirFlowRateSensor(SensorEntity):
             state_class=STATE_CLASS_MEASUREMENT,
             icon='mdi:air-filter',
             native_unit_of_measurement='m³/h',
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            entity_category=EntityCategory.DIAGNOSTIC
         )
         self._controller = controller
         self._attr_unique_id = self._controller.mac + self.name
@@ -106,7 +105,7 @@ class EasyControlsEfficiencySensor(SensorEntity):
             state_class=STATE_CLASS_MEASUREMENT,
             icon='mdi:percent',
             native_unit_of_measurement='%',
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            entity_category=EntityCategory.DIAGNOSTIC
         )
         self._controller = controller
         self._attr_unique_id = self._controller.mac + self.name
@@ -288,7 +287,7 @@ class EasyControlsVersionSensor(SensorEntity):
             key='version',
             name=name,
             icon='mdi:new-box',
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            entity_category=EntityCategory.DIAGNOSTIC
         )
 
         self._controller = controller
@@ -349,7 +348,7 @@ async def async_setup_entry(
                 icon='mdi:air-conditioner',
                 native_unit_of_measurement='%',
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -361,7 +360,7 @@ async def async_setup_entry(
                 icon='mdi:air-conditioner',
                 native_unit_of_measurement=' ',
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -373,7 +372,7 @@ async def async_setup_entry(
                 icon='mdi:air-conditioner',
                 native_unit_of_measurement=' ',
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -385,7 +384,7 @@ async def async_setup_entry(
                 icon='mdi:air-conditioner',
                 native_unit_of_measurement=' ',
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -398,7 +397,7 @@ async def async_setup_entry(
                 native_unit_of_measurement='°C',
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -411,7 +410,7 @@ async def async_setup_entry(
                 native_unit_of_measurement='°C',
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -424,7 +423,7 @@ async def async_setup_entry(
                 native_unit_of_measurement='°C',
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -437,7 +436,7 @@ async def async_setup_entry(
                 native_unit_of_measurement='°C',
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -449,7 +448,7 @@ async def async_setup_entry(
                 icon='mdi:rotate-3d-variant',
                 native_unit_of_measurement='rpm',
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -461,7 +460,7 @@ async def async_setup_entry(
                 icon='mdi:rotate-3d-variant',
                 native_unit_of_measurement='rpm',
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -474,7 +473,7 @@ async def async_setup_entry(
                 native_unit_of_measurement='%',
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -485,7 +484,7 @@ async def async_setup_entry(
                 name=f'{controller.device_name} party mode remaining time',
                 icon='mdi:clock',
                 native_unit_of_measurement='min',
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -497,7 +496,7 @@ async def async_setup_entry(
                 icon='mdi:history',
                 native_unit_of_measurement='h',
                 state_class=STATE_CLASS_TOTAL_INCREASING,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -509,7 +508,7 @@ async def async_setup_entry(
                 icon='mdi:history',
                 native_unit_of_measurement='h',
                 state_class=STATE_CLASS_TOTAL_INCREASING,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -521,7 +520,7 @@ async def async_setup_entry(
                 icon='mdi:history',
                 native_unit_of_measurement='h',
                 state_class=STATE_CLASS_TOTAL_INCREASING,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -533,7 +532,7 @@ async def async_setup_entry(
                 icon='mdi:thermometer-lines',
                 native_unit_of_measurement='%',
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -545,7 +544,7 @@ async def async_setup_entry(
                 icon='mdi:history',
                 native_unit_of_measurement='h',
                 state_class=STATE_CLASS_TOTAL_INCREASING,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsSensor(
@@ -557,7 +556,7 @@ async def async_setup_entry(
                 icon='mdi:thermometer-lines',
                 native_unit_of_measurement='%',
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlFlagSensor(
@@ -568,7 +567,7 @@ async def async_setup_entry(
                 key='ERRORS',
                 name=f'{controller.device_name} errors',
                 icon='mdi:alert-circle',
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlFlagSensor(
@@ -579,7 +578,7 @@ async def async_setup_entry(
                 key='WARNINGS',
                 name=f'{controller.device_name} warnings',
                 icon='mdi:alert-circle-outline',
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlFlagSensor(
@@ -590,7 +589,7 @@ async def async_setup_entry(
                 key='INFORMATION',
                 name=f'{controller.device_name} information',
                 icon='mdi:information-outline',
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+                entity_category=EntityCategory.DIAGNOSTIC
             )
         ),
         EasyControlsAirFlowRateSensor(


### PR DESCRIPTION
### Description
This PR modifies to code to use EntityCategory instance instead of string constant.

### Technical Details
The change required for HA 2022.4

### Issues
references #66