### PR TITLE
fix: return dash for empty flag sensor state

### DIFF
--- a/custom_components/easycontrols/sensor.py
+++ b/custom_components/easycontrols/sensor.py
@@ -201,7 +201,7 @@ class EasyControlFlagSensor(SensorEntity):
         '''
         if value is None:
             return None
-        string = ''
+        string: str = ''
         if value != 0:
             for item in self._flags.items():
                 has_flag = (item[0] & value) == item[0]
@@ -209,6 +209,9 @@ class EasyControlFlagSensor(SensorEntity):
                     if string != '':
                         string += '\n'
                     string += item[1]
+        else:
+            string = '-'
+
         return string
 
     @property


### PR DESCRIPTION
### Description
This PR modifies the returned state of flag based sensors if value is empty. Previously it returned empty string but from version 2022.4 HA handles this value as `unknown` state. Now if no error, warning, information the value is a dash (`-`).