### PR TITLE
fix: remove deprecated iot_class

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "Helios EasyControls Modbus TCP/IP integration",
-  "iot_class": "Local Polling",
   "render_readme": true,
   "zip_release": true,
   "filename": "homeassistant-easycontrols.zip"


### PR DESCRIPTION
### Description
This PR removes deprecated `iot_class` attribute from hacs.json.