### PR TITLE
fix: sort manifest file

### DIFF
--- a/custom_components/easycontrols/manifest.json
+++ b/custom_components/easycontrols/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "easycontrols",
   "name": "Helios Easy Controls",
-  "iot_class": "local_polling",
-  "documentation": "https://github.com/laszlojakab/homeassistant-easycontrols#usage",
-  "issue_tracker": "https://github.com/laszlojakab/homeassistant-easycontrols/issues",
-  "dependencies": [],
-  "config_flow": true,
-  "version": "0.5.8",
   "codeowners": ["@laszlojakab"],
-  "requirements": ["eazyctrl==0.4"]
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/laszlojakab/homeassistant-easycontrols#usage",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/laszlojakab/homeassistant-easycontrols/issues",
+  "requirements": ["eazyctrl==0.4"],
+  "version": "0.5.8"
 }


### PR DESCRIPTION
Sort manifest file according to (new) CI requirements to have alphabetically sorted keys in manifest file except domain and name
https://hacs.xyz/docs/publish/include/#check-manifest