### PR TITLE
fix: remove depracted types

### DIFF
--- a/custom_components/easycontrols/__init__.py
+++ b/custom_components/easycontrols/__init__.py
@@ -4,8 +4,9 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import ConfigType
 
 from custom_components.easycontrols.const import DATA_COORDINATOR, DOMAIN
 from custom_components.easycontrols.coordinator import (
@@ -17,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     config: ConfigType,  # noqa: ARG001
 ) -> bool:
     """
@@ -35,7 +36,7 @@ async def async_setup(
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """
     Initialize the sensors and the fan based on the config entry represents a Helios device.
 
@@ -70,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry) 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistantType, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """
     Executed when a config entry unloaded by Home Assistant.
 
@@ -93,7 +94,7 @@ async def async_unload_entry(hass: HomeAssistantType, config_entry: ConfigEntry)
     return True
 
 
-def is_coordinator_exists(hass: HomeAssistantType, mac_address: str) -> bool:
+def is_coordinator_exists(hass: HomeAssistant, mac_address: str) -> bool:
     """
     Gets the value indicates whether a coordinator already registered
     in hass.data for the given MAC address
@@ -111,7 +112,7 @@ def is_coordinator_exists(hass: HomeAssistantType, mac_address: str) -> bool:
 
 
 def set_coordinator(
-    hass: HomeAssistantType, coordinator: EasyControlsDataUpdateCoordinator
+    hass: HomeAssistant, coordinator: EasyControlsDataUpdateCoordinator
 ) -> None:
     """
     Stores the specified controller in hass.data by its MAC address.
@@ -124,7 +125,7 @@ def set_coordinator(
     hass.data[DOMAIN][DATA_COORDINATOR][coordinator.mac] = coordinator
 
 
-def get_coordinator(hass: HomeAssistantType, mac_address: str) -> EasyControlsDataUpdateCoordinator:
+def get_coordinator(hass: HomeAssistant, mac_address: str) -> EasyControlsDataUpdateCoordinator:
     """
     Gets the coordinator for the given MAC address.
 

--- a/custom_components/easycontrols/binary_sensor.py
+++ b/custom_components/easycontrols/binary_sensor.py
@@ -10,10 +10,10 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import HomeAssistantType
 
 from custom_components.easycontrols import get_coordinator
 from custom_components.easycontrols.const import (
@@ -89,7 +89,7 @@ class EasyControlBinarySensor(BinarySensorEntity):
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:

--- a/custom_components/easycontrols/coordinator.py
+++ b/custom_components/easycontrols/coordinator.py
@@ -12,9 +12,8 @@ from typing import Any, Final, Self, overload
 
 import async_timeout
 from eazyctrl import AsyncEazyController
-from homeassistant.core import CALLBACK_TYPE, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.typing import HomeAssistantType
 
 from custom_components.easycontrols.const import (
     VARIABLE_ARTICLE_DESCRIPTION,
@@ -102,7 +101,7 @@ class EasyControlsDataUpdateCoordinator:
     as soon as possible.
     """
 
-    def __init__(self: Self, hass: HomeAssistantType, device_name: str, host: str):
+    def __init__(self: Self, hass: HomeAssistant, device_name: str, host: str):
         """
         Initialize a new instance of `EasyControlsDataUpdaterCoordinator` class.
 
@@ -468,7 +467,7 @@ class EasyControlsDataUpdateCoordinator:
 
 
 async def create_coordinator(
-    hass: HomeAssistantType, device_name: str, host: str
+    hass: HomeAssistant, device_name: str, host: str
 ) -> EasyControlsDataUpdateCoordinator:
     """Creates and initializes a coordinator instance."""
     coordinator = EasyControlsDataUpdateCoordinator(hass, device_name, host)

--- a/custom_components/easycontrols/fan.py
+++ b/custom_components/easycontrols/fan.py
@@ -5,10 +5,9 @@ from datetime import datetime, timedelta
 from typing import Any, Self
 
 from homeassistant.components.fan import (
-    SUPPORT_PRESET_MODE,
-    SUPPORT_SET_SPEED,
     FanEntity,
     FanEntityDescription,
+    FanEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC
@@ -179,7 +178,7 @@ class EasyControlsFanDevice(FanEntity):
     @property
     def supported_features(self) -> int:
         """Gets the supported features flag."""
-        return SUPPORT_SET_SPEED | SUPPORT_PRESET_MODE
+        return FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
 
     @property
     def speed_count(self) -> int:

--- a/custom_components/easycontrols/fan.py
+++ b/custom_components/easycontrols/fan.py
@@ -12,12 +12,11 @@ from homeassistant.components.fan import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC
-from homeassistant.core import ServiceCall, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.percentage import (
     ordered_list_item_to_percentage,
     percentage_to_ordered_list_item,
@@ -345,7 +344,7 @@ class EasyControlsFanDevice(FanEntity):
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:

--- a/custom_components/easycontrols/sensor.py
+++ b/custom_components/easycontrols/sensor.py
@@ -11,10 +11,10 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import HomeAssistantType
 
 from custom_components.easycontrols import get_coordinator
 from custom_components.easycontrols.const import (
@@ -375,7 +375,7 @@ class EasyControlsSensor[T](SensorEntity):
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> bool:


### PR DESCRIPTION
### Description
This PR removes the use of deprecated `HomeAssistantType` and `SUPPORT_*` constants.