### PR TITLE
fix: add TURN_ON, TURN_OFF feature to fan

### DIFF
--- a/custom_components/easycontrols/fan.py
+++ b/custom_components/easycontrols/fan.py
@@ -178,7 +178,12 @@ class EasyControlsFanDevice(FanEntity):
     @property
     def supported_features(self) -> int:
         """Gets the supported features flag."""
-        return FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
+        return (
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.PRESET_MODE
+            | FanEntityFeature.TURN_ON
+            | FanEntityFeature.TURN_OFF
+        )
 
     @property
     def speed_count(self) -> int:


### PR DESCRIPTION
### Description
This PR adds `TURN_ON`, `TURN_OFF` features to fan entity described in https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/